### PR TITLE
Disable cover include for Nyaa

### DIFF
--- a/Mnema.Providers/Nyaa/NyaaRepository.cs
+++ b/Mnema.Providers/Nyaa/NyaaRepository.cs
@@ -130,6 +130,13 @@ public class NyaaRepository(IHttpClientFactory httpClientFactory): IContentRepos
                 Key = RequestConstants.TitleOverride.Key,
                 Type = FormType.Text
             },
+            new FormControlDefinition
+            {
+                Key = RequestConstants.IncludeCover.Key,
+                Type = FormType.Switch,
+                DefaultOption = "false",
+                Advanced = true,
+            }
         ]);
     }
 


### PR DESCRIPTION
**Changed**
- Changed: Nyaa downloads will not include covers from metadata providers by default anymore